### PR TITLE
Make non-hetrogenous collection sorting more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the chef_auto_accumula
 ## Unreleased
 
 - Make non-hetrogenous collection sorting more robust
+- Provide a better error when unable to find parent config path
 
 ## 0.7.0 - *2024-12-20*
 

--- a/libraries/chef_auto_accumulator/error.rb
+++ b/libraries/chef_auto_accumulator/error.rb
@@ -29,7 +29,7 @@ module ChefAutoAccumulator
       super([
         "Failed to filter a single value for key #{debug_var_output(fkey)} and value #{debug_var_output(fvalue)}.",
         "Result: #{result.count} #{debug_var_output(result)}",
-        "Path: #{debug_var_output(path)}",
+        "Path: #{debug_var_output(path, false)}",
       ].join("\n\n"))
     end
   end

--- a/libraries/chef_auto_accumulator/resource.rb
+++ b/libraries/chef_auto_accumulator/resource.rb
@@ -108,6 +108,8 @@ module ChefAutoAccumulator
                     end
       config_key = translate_property_value(key) if key
 
+      raise AccumlatorConfigNoParentPathError, "Config path for #{path.map { |p| "['#{p}']" }.join} is nil" if config_path.nil?
+
       log_string = ''
       log_string.concat("\nPerfoming action :#{action} on configuration ")
       log_string.concat("Path: #{path.join(' -> ')}\n#{debug_var_output(config_path)}\n")
@@ -470,8 +472,6 @@ module ChefAutoAccumulator
       log_chef(:debug) { "Filtering #{debug_var_output(path, false)} on #{debug_var_output(key)} | #{debug_var_output(value)}" }
       log_chef(:trace) { "Path data\n#{debug_var_output(path)}" }
       filtered_object = path.filter { |v| v[key].eql?(value) }
-
-      return if filtered_object.empty?
 
       log_chef(:debug) { "Got filtered value #{debug_var_output(filtered_object, false)}" }
       log_chef(:trace) { "Filtered value data\n#{debug_var_output(filtered_object)}" }


### PR DESCRIPTION
# Description

We should sort on the first common non-nil key instead of the first common present one. If clean_nil_values is set in a downstream resource then the original method will possibly try to sort on a `nil` causing a raise.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
