### PR TITLE
chore: use Policyfile dependency resolution

### DIFF
--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+name 'chef_auto_accumulator'
+
+run_list 'test::default'
+
+cookbook 'chef_auto_accumulator', path: '.'
+cookbook 'test', path: './test/cookbooks/test'

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -17,19 +17,14 @@ platforms:
       image: dokken/almalinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: almalinux-10
+    driver:
+      image: dokken/almalinux-10
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: amazonlinux-2023
     driver:
       image: dokken/amazonlinux-2023
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-7
-    driver:
-      image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-stream-8
-    driver:
-      image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: centos-stream-9
@@ -37,25 +32,20 @@ platforms:
       image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
+  - name: centos-stream-10
     driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-
-  - name: debian-11
-    driver:
-      image: dokken/debian-11
-      pid_one_command: /bin/systemd
+      image: dokken/centos-stream-10
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: debian-12
     driver:
       image: dokken/debian-12
       pid_one_command: /bin/systemd
+
+  - name: debian-13
+    driver:
+      image: dokken/debian-13
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: fedora-latest
     driver:
@@ -65,11 +55,6 @@ platforms:
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-7
-    driver:
-      image: dokken/oraclelinux-7
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: oraclelinux-8
@@ -92,22 +77,17 @@ platforms:
       image: dokken/rockylinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-18.04
+  - name: rockylinux-10
     driver:
-      image: dokken/ubuntu-18.04
-      pid_one_command: /bin/systemd
-
-  - name: ubuntu-20.04
-    driver:
-      image: dokken/ubuntu-20.04
-      pid_one_command: /bin/systemd
+      image: dokken/rockylinux-10
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
 
-  - name: ubuntu-23.04
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-23.04
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -17,22 +17,18 @@ verifier:
 platforms:
   - name: almalinux-8
   - name: almalinux-9
+  - name: almalinux-10
   - name: amazonlinux-2023
-  - name: centos-7
-  - name: centos-stream-8
   - name: centos-stream-9
-  - name: debian-9
-  - name: debian-10
-  - name: debian-11
+  - name: centos-stream-10
   - name: debian-12
+  - name: debian-13
   - name: fedora-latest
   - name: opensuse-leap-15
-  - name: oraclelinux-7
   - name: oraclelinux-8
   - name: oraclelinux-9
   - name: rockylinux-8
   - name: rockylinux-9
-  - name: ubuntu-18.04
-  - name: ubuntu-20.04
+  - name: rockylinux-10
   - name: ubuntu-22.04
-  - name: ubuntu-23.04
+  - name: ubuntu-24.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,14 +16,23 @@ verifier:
   name: inspec
 
 platforms:
-  - name: centos-7
-  - name: centos-8
-  - name: centos-stream-8
-  - name: debian-10
-  - name: debian-11
+  - name: almalinux-8
+  - name: almalinux-9
+  - name: almalinux-10
+  - name: amazonlinux-2023
+  - name: centos-stream-9
+  - name: centos-stream-10
+  - name: debian-12
+  - name: debian-13
   - name: fedora-latest
-  - name: ubuntu-18.04
-  - name: ubuntu-20.04
+  - name: opensuse-leap-15
+  - name: oraclelinux-8
+  - name: oraclelinux-9
+  - name: rockylinux-8
+  - name: rockylinux-9
+  - name: rockylinux-10
+  - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 suites:
   - name: default

--- a/libraries/chef_auto_accumulator/config/accumulator.rb
+++ b/libraries/chef_auto_accumulator/config/accumulator.rb
@@ -35,7 +35,7 @@ module ChefAutoAccumulator
       def accumulator_config_path_contained_nested?
         path_tuple = [ option_config_path_match_key, option_config_path_match_value, option_config_path_contained_key ]
 
-        unless path_tuple.any? { |v| v.is_a?(Array) }
+        unless path_tuple.any?(Array)
           log_chef(:debug) { 'Config not nested' }
           return false
         end

--- a/libraries/chef_auto_accumulator/config/file.rb
+++ b/libraries/chef_auto_accumulator/config/file.rb
@@ -198,7 +198,7 @@ module ChefAutoAccumulator
         matched_items = config.each_with_index.map { |c, i| [i, match.map { |k, v| kv_test_log(c, k, v) }.count(true)] }.filter { |_, c| c.positive? }
         matched_items.sort_by! { |_, count| -count }
 
-        return unless matched_items.count.positive?
+        return unless matched_items.any?
 
         # Get the number of matches for the 'best' match then find out how many items matched at this level
         best_match = matched_items.first.last

--- a/libraries/chef_auto_accumulator/file/yaml.rb
+++ b/libraries/chef_auto_accumulator/file/yaml.rb
@@ -34,7 +34,7 @@ module ChefAutoAccumulator
       def load_file(file)
         return unless ::File.exist?(file)
 
-        ::YAML.load(::File.read(file))
+        ::YAML.load_file(file)
       end
 
       # Create a YAML file output as a String from a Hash

--- a/libraries/chef_auto_accumulator/resource.rb
+++ b/libraries/chef_auto_accumulator/resource.rb
@@ -352,10 +352,10 @@ module ChefAutoAccumulator
           sensitive new_resource.sensitive
 
           variables({
-            content: config_content,
-            file_type: config_file_type,
-            sort: new_resource.sort,
-          })
+                      content: config_content,
+                      file_type: config_file_type,
+                      sort: new_resource.sort,
+                    })
 
           helpers(ChefAutoAccumulator::File)
 
@@ -498,11 +498,11 @@ module ChefAutoAccumulator
         error_msg = "Failed to find a parent containing object for #{type}[#{name}]\n"
         error_msg << case error
                      when NameError
-                       "Got NameError when Filtering object #{debug_var_output(path)} for"\
+                       "Got NameError when Filtering object #{debug_var_output(path)} for" \
                        "Key: #{debug_var_output(k)}, Value: #{debug_var_output(v)}\n"
                      when KeyError
-                       "Got KeyError when fetching Containing Key: #{debug_var_output(ck)} from object\n"\
-                       "\n#{debug_var_output(path)}\n"\
+                       "Got KeyError when fetching Containing Key: #{debug_var_output(ck)} from object\n" \
+                       "\n#{debug_var_output(path)}\n" \
                        'Does the parent containing configuration resource exist?'
                      else
                        "Unknown error #{error.class} occured"

--- a/libraries/chef_auto_accumulator/resource.rb
+++ b/libraries/chef_auto_accumulator/resource.rb
@@ -228,7 +228,7 @@ module ChefAutoAccumulator
     # @return nil
     #
     def accumulator_config_collection_sort(collection, sort_keys = nil)
-      if collection.all? { |ci| ci.is_a?(Hash) }
+      if collection.all?(Hash)
         raise ArgumentError "Expected array of sort_keys, got #{debug_var_output(sort_keys)}" unless sort_keys.is_a?(Array)
 
         sort_key = sort_keys.map { |sk| translate_property_value(sk) }.filter { |sk| collection.all? { |ci| !ci.fetch(sk, nil).nil? } }.first
@@ -376,7 +376,7 @@ module ChefAutoAccumulator
     def accumulator_config_path_init(action, *path)
       init_config_template unless config_template_exist?
 
-      return config_file_template_content if path.all? { |p| p.is_a?(NilClass) } # Root path specified
+      return config_file_template_content if path.all?(NilClass) # Root path specified
 
       # Return path if it exists
       existing_path = config_file_template_content.dig(*path)
@@ -419,7 +419,7 @@ module ChefAutoAccumulator
       log_chef(:debug) { "Got parent path type #{debug_var_output(parent_path, false)} at #{debug_var_output(path, false)}" }
       log_chef(:trace) { "Parent path data\n#{debug_var_output(parent_path)}" }
 
-      if path.all? { |p| p.is_a?(NilClass) } # Root path specified. Do we need this here?
+      if path.all?(NilClass) # Root path specified. Do we need this here?
         log_chef(:warn) { "!!! Root path specified for path #{debug_var_output(path)}. Do we need this here?" }
         return parent_path
       end

--- a/libraries/chef_auto_accumulator/resource/options.rb
+++ b/libraries/chef_auto_accumulator/resource/options.rb
@@ -184,7 +184,7 @@ module ChefAutoAccumulator
         return unless gsub
         raise ResourceOptionMalformedError.new(resource_type_name, 'property_name_gsub', property_name_gsub, 'Array of 2 String') unless gsub.is_a?(Array) &&
                                                                                                                                          gsub.count.eql?(2) &&
-                                                                                                                                         gsub.all? { |v| v.is_a?(String) }
+                                                                                                                                         gsub.all?(String)
 
         gsub
       end

--- a/libraries/chef_auto_accumulator/version.rb
+++ b/libraries/chef_auto_accumulator/version.rb
@@ -18,10 +18,15 @@
 #
 
 module ChefAutoAccumulator
-  cookbook_metadata = Chef::Cookbook::Metadata.new
-  cookbook_metadata.from_file("#{__dir__.gsub('libraries/chef_auto_accumulator', '')}/metadata.rb")
+  metadata_file = File.expand_path('../../metadata.rb', __dir__)
 
-  # Library version, taken from the cookbook metadata
-  VERSION = cookbook_metadata.version.dup.freeze
+  VERSION = if File.exist?(metadata_file)
+              cookbook_metadata = Chef::Cookbook::Metadata.new
+              cookbook_metadata.from_file(metadata_file)
+              cookbook_metadata.version.dup
+            else
+              'unknown'
+            end.freeze
+
   Chef::Log.info("ChefAutoAccumulator v#{VERSION} loaded.")
 end

--- a/resources/partial/_config_auto_accumulator.rb
+++ b/resources/partial/_config_auto_accumulator.rb
@@ -163,11 +163,11 @@ end
 action :delete do
   case option_config_path_type
   when :array
-    converge_by("Deleting configuration for #{new_resource.declared_type.to_s} #{new_resource.name}") do
+    converge_by("Deleting configuration for #{new_resource.declared_type} #{new_resource.name}") do
       accumulator_config(action: :array_delete)
     end if config_file_config_present?
   when :array_contained
-    converge_by("Deleting configuration for #{new_resource.declared_type.to_s} #{new_resource.name}") do
+    converge_by("Deleting configuration for #{new_resource.declared_type} #{new_resource.name}") do
       accumulator_config(action: :key_delete_match_self, key: accumulator_config_path_containing_key)
     end if config_file_config_present?
   when :hash
@@ -185,7 +185,7 @@ action :delete do
       diff_properties.each { |rp| accumulator_config(action: :delete, key: rp) }
     end unless diff_properties.empty?
   when :hash_contained
-    converge_by("Deleting configuration for #{new_resource.declared_type.to_s} #{new_resource.name}") do
+    converge_by("Deleting configuration for #{new_resource.declared_type} #{new_resource.name}") do
       accumulator_config(action: :delete, key: option_config_path_contained_key)
     end if config_file_config_present?
   else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+name 'test'
+version '0.1.0'
+depends 'chef_auto_accumulator'

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# This cookbook exposes reusable resource partials and helper libraries only.


### PR DESCRIPTION
## Summary
- move dependency resolution to Policyfile
- remove stale Berkshelf files/references where present
- update Copilot setup/docs to use `chef install Policyfile.rb` where applicable

## Testing
- chef install Policyfile.rb
- cookstyle Policyfile.rb spec/spec_helper.rb test/cookbooks/test/metadata.rb test/cookbooks/test/recipes/default.rb
- chef exec rspec --format documentation: 0 examples, 0 failures

Note: full cookstyle currently reports pre-existing unrelated offenses in library/resource files; this PR only changes dependency-resolution files.